### PR TITLE
added option to disable ssl verification

### DIFF
--- a/exchange-calendar-to-org.cfg.example
+++ b/exchange-calendar-to-org.cfg.example
@@ -2,5 +2,6 @@
 email: your.email@example.com
 password: supersecretpassword
 sync_days: 60
+verify_ssl: True
 org_file: C:\org\Calendar.org
 timezone_string: Europe/London

--- a/exchange-calendar-to-org.py
+++ b/exchange-calendar-to-org.py
@@ -26,6 +26,7 @@ def main():
     sync_days = int(config.get('Settings', 'sync_days'))
     org_file_path = config.get('Settings', 'org_file')
     tz_string = config.get('Settings', 'timezone_string')
+    sslverify = config.getboolean('Settings', 'verify_ssl')
 
     tz = EWSTimeZone.timezone(tz_string)
 
@@ -38,7 +39,7 @@ def main():
             autodiscover=True,
             access_type=DELEGATE)
     else:
-        server = Configuration(server=server_url, credentials=credentials)
+        server = Configuration(server=server_url, credentials=credentials, verify_ssl=sslverify)
         account = Account(
             primary_smtp_address=email,
             config=server,


### PR DESCRIPTION
When not using autodiscovery, chances are, that the server has a
self-signed certificate. In that case, we may want to disable ssl
verification. Assuming, that we configured server_url, we know what we
are doing and consciously accept the risk. Default in config file is
to verify.

Please notice, that newer version of exchangelibs (>1.10) uses
NoVerifyHTTPAdapter for the same purpose. Then the code should utilise
this:

  from exchangelib.protocol import NoVerifyHTTPAdapter
  BaseProtocol.HTTP_ADAPTER_CLS = NoVerifyHTTPAdapter

Unfortunatelly, with older exchangelibs, we have to uese verif_ssl.